### PR TITLE
chore: merge two radiator speed into one

### DIFF
--- a/networks/primary/network.json
+++ b/networks/primary/network.json
@@ -611,17 +611,12 @@
       "description": "Percentage value from 0% to 100% of radiator fans and pumps speed, 8bit",
       "interval": 1000,
       "contents": {
-        "inverters_radiator_speed": {
+        "radiators_speed": {
           "type": "float32",
           "range": [0, 1],
           "force": "uint16"
         },
-        "motors_radiator_speed": {
-          "type": "float32",
-          "range": [0, 1],
-          "force": "uint16"
-        },
-        "pump_speed": {
+        "pumps_speed": {
           "type": "float32",
           "range": [0, 1],
           "force": "uint16"


### PR DESCRIPTION
note: change pump to pumps and radiator to radiators because the value represents the same value for each left/right cooling device